### PR TITLE
Fix error when is string in hook_node_access.

### DIFF
--- a/backend_manual.module
+++ b/backend_manual.module
@@ -133,7 +133,8 @@ function backend_manual_node_view($node, $view_mode, $langcode) {
  * Implements hook_node_access().
  */
 function backend_manual_node_access($node, $op, $account) {
-  if ($node->type == 'manual_page' && $op = 'view') {
+  $type = is_string($node) ? $node : $node->type;
+  if ($type == 'manual_page' && $op == 'view') {
     if (user_access('access backend manual')) {
       return NODE_ACCESS_ALLOW;
     }


### PR DESCRIPTION
- Chose assez étrange, dans la doc du hook_node_access il est dit que $node peut être une chaîne de caractère correspondant au type de node testé : 
https://api.drupal.org/api/drupal/modules!node!node.api.php/function/hook_node_access/7.x
- Le paramètre $op testé était en fait assigné, avec un seul signe "=".